### PR TITLE
Updated Bootstrap_Main.ps1

### DIFF
--- a/Runbooks/startstop/1.0/Bootstrap_Main.ps1
+++ b/Runbooks/startstop/1.0/Bootstrap_Main.ps1
@@ -8,6 +8,7 @@
 Version History
 v1.0 - Initial Release
 v2.0 - Refactored Az modules
+v2.1 - Added possibility for disabling schedules after deploy
 #>
 
 
@@ -17,7 +18,6 @@ Write-Output 'Bootstrap main script execution started...'
 
 #---------Inputs variables for NewRunAsAccountCertKeyVault.ps1 child bootstrap script--------------
 $automationAccountName = Get-AutomationVariable -Name 'Internal_AutomationAccountName'
-$SubscriptionId = Get-AutomationVariable -Name 'Internal_AzureSubscriptionId'
 $aroResourceGroupName = Get-AutomationVariable -Name 'Internal_ResourceGroupName'
 
 $startScheduleDisabled = Get-AutomationVariable -Name 'Internal_StartScheduleDisabled'
@@ -90,7 +90,7 @@ try {
         #Webhook creation for variable Internal_AutoSnooze_WebhookUri
         $checkWebhook = Get-AzAutomationWebhook -Name $webhookNameforAutoStopVM -AutomationAccountName $AutomationAccountName -ResourceGroupName $aroResourceGroupName -ErrorAction SilentlyContinue
 
-        if ($checkWebhook -eq $null) {
+        if ($null -eq $checkWebhook) {
             Write-Output "Executing Step-1 : Create the webhook for $($runbookNameforAutoStopVM)..."
 
             $ExpiryTime = (Get-Date).AddDays(730)
@@ -122,7 +122,7 @@ try {
         #Webhook creation for variable Internal_AutoSnooze_ARM_WebhookUri
         $checkWebhook = Get-AzAutomationWebhook -Name $webhookNameforAutoStopVMARM -AutomationAccountName $AutomationAccountName -ResourceGroupName $aroResourceGroupName -ErrorAction SilentlyContinue
 
-        if ($checkWebhook -eq $null) {
+        if ($null -eq $checkWebhook) {
             Write-Output "Executing Step-1 : Create the webhook for $($runbookNameforAutoStopVMARM)..."
 
             $ExpiryTime = (Get-Date).AddDays(730)
@@ -169,7 +169,7 @@ try {
 
         $checkMegaSchedule = Get-AzAutomationSchedule -Name $scheduleNameforCreateAlert -AutomationAccountName $automationAccountName -ResourceGroupName $aroResourceGroupName -ErrorAction SilentlyContinue
 
-        if ($checkMegaSchedule -eq $null) {
+        if ($null -eq $checkMegaSchedule) {
             Write-Output 'Executing Step-2 : Create schedule for AutoStop_CreateAlert_Parent runbook ...'
 
             #-----Configure the Start & End Time----
@@ -229,7 +229,7 @@ try {
         #Stops every friday 6PM
         $StopVmUTCTime = (Get-Date '01:00:00').AddDays(1).ToUniversalTime()
 
-        if ($checkSeqSnoozeStart -eq $null) {
+        if ($null -eq $checkSeqSnoozeStart) {
             Write-Output 'Executing Step-3 : Create start schedule for SequencedStartStop_Parent runbook ...'
 
             #---Create the schedule at the Automation Account level---
@@ -248,7 +248,7 @@ try {
             Write-Output "Successfully Registered the Schedule in the Runbook ($($runbookNameforARMVMOptimization))..."
         }
 
-        if ($checkSeqSnoozeStop -eq $null) {
+        if ($null -eq $checkSeqSnoozeStop) {
             Write-Output 'Executing Step-3 : Create stop schedule for SequencedStartStop_Parent runbook ...'
 
             #---Create the schedule at the Automation Account level---
@@ -267,7 +267,7 @@ try {
             Write-Output "Successfully Registered the Schedule in the Runbook ($($runbookNameforARMVMOptimization))..."
         }
 
-        if ($checkSeqSnoozeStart -ne $null -and $checkSeqSnoozeStop -ne $null) {
+        if ($null -ne $checkSeqSnoozeStart -and $null -ne $checkSeqSnoozeStop) {
             Write-Output 'Schedule already available. Ignoring Step-3...'
         }
         Write-Output 'Completed Step-3 ...'
@@ -317,7 +317,7 @@ try {
 
         $checkScheduleBootstrap = Get-AzAutomationSchedule -AutomationAccountName $automationAccountName -Name 'startBootstrap' -ResourceGroupName $aroResourceGroupName -ErrorAction SilentlyContinue
 
-        if ($checkScheduleBootstrap -ne $null) {
+        if ($null -ne $checkScheduleBootstrap) {
 
             Write-Output 'Removing Bootstrap Schedule...'
 


### PR DESCRIPTION
There was a conoundrum regarding enabling and disabling schedules with ARM/Bicep. Turns out this is not possible, and must be done with a bootstrap powershell script.

I have added the logic for disabling start or stop schedule based on an automation variable, but this is not enabled by default. Bootstrap powershell file is not even scheduled for startup atm. This enables the possibility of disabling the schedules via bootstrap file on deploy. They are enabled by default, and will only be disabled if the correct variables have a 'true' value.